### PR TITLE
#25 Fix Maven Central badge and update plugin coordinates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Maven Distribution Verifier Plugin
 
-image:https://img.shields.io/maven-central/v/com.dataliquid/distribution-verifier-maven-plugin.svg[Maven Central,link=https://search.maven.org/search?q=g:%22com.dataliquid%22%20AND%20a:%22distribution-verifier-maven-plugin%22]
+image:https://img.shields.io/maven-central/v/com.dataliquid.maven/distribution-verifier-maven-plugin.svg[Maven Central,link=https://search.maven.org/search?q=g:%22com.dataliquid.maven%22%20AND%20a:%22distribution-verifier-maven-plugin%22]
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg[License,link=https://opensource.org/licenses/Apache-2.0]
 
 == Introduction
@@ -27,9 +27,9 @@ Add the plugin to your Maven `pom.xml`:
 <build>
   <plugins>
     <plugin>
-      <groupId>com.dataliquid</groupId>
+      <groupId>com.dataliquid.maven</groupId>
       <artifactId>distribution-verifier-maven-plugin</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
       <configuration>
         <distributionFile>${project.build.directory}/${project.build.finalName}.zip</distributionFile>
         <whitelistFile>${project.basedir}/src/main/resources/whitelist.xml</whitelistFile>
@@ -212,7 +212,7 @@ Verify a distribution file with default settings:
 [source,xml]
 ----
 <plugin>
-  <groupId>com.dataliquid</groupId>
+  <groupId>com.dataliquid.maven</groupId>
   <artifactId>distribution-verifier-maven-plugin</artifactId>
   <version>1.0.0</version>
   <executions>


### PR DESCRIPTION
## Description
This PR fixes the incorrect Maven coordinates in the README documentation.

## Changes
- Fixed Maven Central badge to use correct groupId: 
- Updated all plugin references to use correct groupId
- Updated version to latest stable release (1.0.3)

## Verification
The plugin is available in Maven Central at:
https://repo1.maven.org/maven2/com/dataliquid/maven/distribution-verifier-maven-plugin/

Fixes #25