### PR TITLE
Add CI build badge and update version in documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 = Maven Distribution Verifier Plugin
 
-image:https://img.shields.io/maven-central/v/com.dataliquid.maven/distribution-verifier-maven-plugin.svg[Maven Central,link=https://search.maven.org/search?q=g:%22com.dataliquid.maven%22%20AND%20a:%22distribution-verifier-maven-plugin%22]
+image:https://github.com/dataliquid/distribution-verifier-maven-plugin/actions/workflows/ci.yml/badge.svg[CI Build,link=https://github.com/dataliquid/distribution-verifier-maven-plugin/actions/workflows/ci.yml]
+image:https://maven-badges.herokuapp.com/maven-central/com.dataliquid.maven/distribution-verifier-maven-plugin/badge.svg[Maven Central,link=https://maven-badges.herokuapp.com/maven-central/com.dataliquid.maven/distribution-verifier-maven-plugin]
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg[License,link=https://opensource.org/licenses/Apache-2.0]
 
 == Introduction
@@ -214,7 +215,7 @@ Verify a distribution file with default settings:
 <plugin>
   <groupId>com.dataliquid.maven</groupId>
   <artifactId>distribution-verifier-maven-plugin</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.3</version>
   <executions>
     <execution>
       <phase>verify</phase>


### PR DESCRIPTION
## Summary
- Added GitHub Actions CI build status badge to README
- Updated plugin version to reflect latest release

## Changes
- Added CI build badge showing GitHub Actions status
- Updated version from 1.0.0 to 1.0.3 in the example configuration

## Motivation
The CI badge provides immediate visibility of the build status, making it easier for users to:
- Check if the build is passing before using the plugin
- Have confidence in the stability of the project
- Have accurate version information in the documentation

Fixes #31