### PR TITLE
Upgrade to parent-oss 2.0.0 and remove redundant plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.dataliquid</groupId>
 		<artifactId>parent-oss</artifactId>
-		<version>1.1.0</version>
+		<version>2.0.0</version>
 	</parent>
 	<groupId>com.dataliquid.maven</groupId>
 	<artifactId>distribution-verifier-maven-plugin</artifactId>
@@ -154,7 +154,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.13.0</version>
 				<configuration>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.target}</target>
@@ -164,7 +163,7 @@
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
 				<configuration>
-					<header>https://raw.githubusercontent.com/dataliquid/parent-oss/1.0.0/src/main/resources/licence/APACHE-2.tmpl.txt</header>
+					<header>https://raw.githubusercontent.com/dataliquid/parent-oss/2.0.0/src/main/resources/licence/APACHE-2.tmpl.txt</header>
 					<properties>
 						<owner>dataliquid GmbH</owner>
 						<website>www.dataliquid.com</website>
@@ -212,7 +211,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.3</version>
 				<configuration>
 					<systemPropertyVariables>
 						<slf4j.provider>org.slf4j.simple.SimpleServiceProvider</slf4j.provider>
@@ -222,7 +220,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.3.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/domain/Entry.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/domain/Entry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/domain/ResultEntry.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/domain/ResultEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/domain/VerificationStatus.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/domain/VerificationStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/domain/VerifierResult.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/domain/VerifierResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/mojo/GenerateMojo.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/mojo/GenerateMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/mojo/VerifyMojo.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/mojo/VerifyMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/report/AbstractXmlReport.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/report/AbstractXmlReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/report/JUnitReport.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/report/JUnitReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/report/Report.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/report/Report.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/report/XmlReport.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/report/XmlReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/service/GenerateService.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/service/GenerateService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/service/VerifierService.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/service/VerifierService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/report/JunitReportTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/report/JunitReportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/report/XmlReportTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/report/XmlReportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/service/GenerateServiceTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/service/GenerateServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/service/VerifierServiceTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/service/VerifierServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2019 dataliquid GmbH | www.dataliquid.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Summary
- Upgraded parent-oss to version 2.0.0
- Removed plugin versions that are now inherited from the parent POM

## Changes
- Updated parent-oss version from 1.1.0 to 2.0.0
- Removed explicit versions for the following plugins (now inherited):
  - maven-compiler-plugin
  - maven-surefire-plugin
  - maven-resources-plugin
- Updated license-maven-plugin header URL to reference parent-oss 2.0.0

## Benefits
- Consistent plugin versions across all projects using parent-oss
- Reduced maintenance by centralizing version management
- Cleaner POM with less duplication

## Test plan
- [x] Build passes with `mvn clean compile`
- [ ] All tests pass
- [ ] Integration with CI/CD pipeline

Fixes #33