### PR TITLE
Update to Java 11 and Hamcrest 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21' ]
+        java: [ '11', '17', '21' ]
     
     name: Build with Java ${{ matrix.java }}
     

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,10 +33,10 @@ jobs:
         languages: ${{ matrix.language }}
         queries: +security-and-quality
 
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
 

--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -25,5 +25,5 @@ jobs:
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}
-      java-version: '8'
+      java-version: '11'
       java-distribution: 'temurin'

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -25,5 +25,5 @@ jobs:
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}
-      java-version: '8'
+      java-version: '11'
       java-distribution: 'temurin'

--- a/README.adoc
+++ b/README.adoc
@@ -19,6 +19,11 @@ If there are any discrepancies in the defined hash values or files that are not 
 * JUnit report format support
 * Maven integration
 
+== Requirements
+
+* Java 11 or higher
+* Maven 3.6.0 or higher
+
 == Quick Start
 
 Add the plugin to your Maven `pom.xml`:

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<maven.version>3.9.10</maven.version>
 		<maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
 		<maven-plugin-plugin.version>3.15.1</maven-plugin-plugin.version>
@@ -137,7 +137,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<artifactId>hamcrest</artifactId>
 			<version>3.0</version>
 			<scope>test</scope>
 		</dependency>

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/service/VerifierServiceTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/service/VerifierServiceTest.java
@@ -17,7 +17,7 @@ package com.dataliquid.maven.distribution.verifier.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 


### PR DESCRIPTION
## Summary
- Migrate project to Java 11 as minimum requirement
- Update Hamcrest to version 3.0 for better compatibility

## Changes
- Updated Maven compiler source and target to Java 11
- Removed Java 8 from CI build matrix (now tests with Java 11, 17, 21)
- Updated all GitHub workflows to use Java 11
- Added Requirements section to README specifying Java 11+
- Fixed Hamcrest imports for version 3.0 compatibility
- Changed hamcrest-library dependency to hamcrest

## Testing
All tests pass with Java 11, 17, and 21.

Closes #16