### PR TITLE
Migrate from JUnit 4 to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,9 @@
 			<version>1.17</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.11.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/report/JunitReportTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/report/JunitReportTest.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.dataliquid.maven.distribution.verifier.domain.ResultEntry;
 
@@ -32,7 +32,7 @@ public class JunitReportTest
 {
     private Report reportService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException
     {
         reportService = new JUnitReport();

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/report/XmlReportTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/report/XmlReportTest.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.dataliquid.maven.distribution.verifier.domain.ResultEntry;
 
@@ -32,7 +32,7 @@ public class XmlReportTest
 {
     private Report reportService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException
     {
         reportService = new XmlReport();

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/service/GenerateServiceTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/service/GenerateServiceTest.java
@@ -15,14 +15,14 @@
  */
 package com.dataliquid.maven.distribution.verifier.service;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GenerateServiceTest
 {
@@ -30,7 +30,7 @@ public class GenerateServiceTest
 
     private File outputDirectory;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException
     {
         verifierService = new GenerateService();

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/service/VerifierServiceTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/service/VerifierServiceTest.java
@@ -27,8 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.dataliquid.maven.distribution.verifier.domain.ResultEntry;
 import com.dataliquid.maven.distribution.verifier.domain.VerifierResult;
@@ -42,7 +42,7 @@ public class VerifierServiceTest
 
     private Map<String, String> variables;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException
     {
         verifierService = new VerifierService();


### PR DESCRIPTION
## Summary
- Migrate testing framework from JUnit 4 to JUnit 5
- Update all test classes to use modern JUnit 5 API

## Changes
- Replace junit 4.13.2 dependency with junit-jupiter 5.11.4
- Update all test classes to use JUnit 5 annotations:
  - Replace @Before with @BeforeEach
  - Update imports from org.junit to org.junit.jupiter.api
- Fix assertThat import in GenerateServiceTest to use Hamcrest

## Testing
All 16 tests pass successfully with JUnit 5.

Closes #41