### PR TITLE
Update parent pom to version 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.dataliquid</groupId>
 		<artifactId>parent-oss</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0</version>
 	</parent>
 	<groupId>com.dataliquid.maven</groupId>
 	<artifactId>distribution-verifier-maven-plugin</artifactId>
@@ -163,7 +163,7 @@
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
 				<configuration>
-					<header>https://raw.githubusercontent.com/dataliquid/parent-oss/2.0.0/src/main/resources/licence/APACHE-2.tmpl.txt</header>
+					<header>https://raw.githubusercontent.com/dataliquid/parent-oss/2.1.0/src/main/resources/licence/APACHE-2.tmpl.txt</header>
 					<properties>
 						<owner>dataliquid GmbH</owner>
 						<website>www.dataliquid.com</website>


### PR DESCRIPTION
## Summary
- Updated parent-oss version from 2.0.0 to 2.1.0
- Updated license header URL to reference version 2.1.0
- Ensures compatibility with latest parent pom features

## Test plan
- [ ] Build passes with `mvn clean install`
- [ ] All tests pass
- [ ] Plugin goals work correctly
- [ ] No dependency conflicts

Closes #42