### PR TITLE
Fix GenerateServiceTest for JUnit 5.13.3 compatibility

### DIFF
--- a/src/test/java/com/dataliquid/maven/distribution/verifier/service/GenerateServiceTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/service/GenerateServiceTest.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 public class GenerateServiceTest
 {
@@ -49,7 +52,10 @@ public class GenerateServiceTest
         verifierService.generate(distributionArchive, outputDirectory, whitelist);
 
         // then
-        assertThat(expectedWhitelist, isSimilarTo(whitelist).ignoreWhitespace().ignoreComments());
+        assertThat(expectedWhitelist, isSimilarTo(whitelist)
+            .ignoreWhitespace()
+            .ignoreComments()
+            .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes)));
 
     }
 


### PR DESCRIPTION
## Summary
- Fixed failing test in GenerateServiceTest that was causing JUnit 5.13.3 upgrade (PR #49) to fail
- The test now properly handles non-deterministic file ordering from `File.listFiles()`
- No production code changes required

## Problem
The test was comparing XML files expecting elements in a specific order, but `File.listFiles()` doesn't guarantee order. With JUnit 5.13.3 or different test environments, files were processed in a different order causing test failures.

## Solution
Modified the test to use XMLUnit's `withNodeMatcher` with `ElementSelectors.byNameAndAllAttributes` to compare XML elements by their content rather than order.

## Test plan
- [x] Run `mvn test` - all tests pass
- [x] Run specific test `mvn test -Dtest=GenerateServiceTest#shouldGenerateWhitelist` - passes
- [x] Verified the fix works with both file orderings