### PR TITLE
#56 Update to maven.compiler.release property and adjust CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17', '21' ]
+        java: [ '17', '21' ]
     
     name: Build with Java ${{ matrix.java }}
     

--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -25,5 +25,5 @@ jobs:
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}
-      java-version: '11'
+      java-version: '17'
       java-distribution: 'temurin'

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -25,5 +25,5 @@ jobs:
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}
-      java-version: '11'
+      java-version: '17'
       java-distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,7 @@
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.release>8</maven.compiler.release>
 		<maven.version>3.9.11</maven.version>
 		<maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
 		<maven-plugin-plugin.version>3.15.1</maven-plugin-plugin.version>
@@ -151,14 +150,6 @@
 	</dependencies>
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>${maven.compiler.source}</source>
-					<target>${maven.compiler.target}</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- Replaced maven.compiler.source/target with maven.compiler.release=8
- Removed explicit maven-compiler-plugin configuration
- Updated CI pipeline to test with Java 17 and 21 only
- Updated gitflow workflows to use Java 17

## Test plan
- [x] Maven build successful with Java 8 compilation
- [x] CI pipeline passes with Java 17 and 21
- [x] Gitflow workflows work with Java 17

Closes #56