### PR TITLE
#58 Upgrade to parent-oss 2.2.4 with traditional formatter style

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,10 +33,10 @@ jobs:
         languages: ${{ matrix.language }}
         queries: +security-and-quality
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.dataliquid</groupId>
 		<artifactId>parent-oss</artifactId>
-		<version>2.2.2</version>
+		<version>2.2.3</version>
 	</parent>
 	<groupId>com.dataliquid.maven</groupId>
 	<artifactId>distribution-verifier-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.dataliquid</groupId>
 		<artifactId>parent-oss</artifactId>
-		<version>2.2.1</version>
+		<version>2.2.2</version>
 	</parent>
 	<groupId>com.dataliquid.maven</groupId>
 	<artifactId>distribution-verifier-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.dataliquid</groupId>
 		<artifactId>parent-oss</artifactId>
-		<version>2.2.3</version>
+		<version>2.2.4-SNAPSHOT</version>
 	</parent>
 	<groupId>com.dataliquid.maven</groupId>
 	<artifactId>distribution-verifier-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
 				<configuration>
-					<configFile>codestyles/tradional/eclipse-codestyle.xml</configFile>
+					<configFile>codestyles/traditional/eclipse-codestyle.xml</configFile>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.dataliquid</groupId>
 		<artifactId>parent-oss</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.2.4</version>
 	</parent>
 	<groupId>com.dataliquid.maven</groupId>
 	<artifactId>distribution-verifier-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.dataliquid</groupId>
 		<artifactId>parent-oss</artifactId>
-		<version>2.1.0</version>
+		<version>2.2.1</version>
 	</parent>
 	<groupId>com.dataliquid.maven</groupId>
 	<artifactId>distribution-verifier-maven-plugin</artifactId>
@@ -150,6 +150,13 @@
 	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>net.revelc.code.formatter</groupId>
+				<artifactId>formatter-maven-plugin</artifactId>
+				<configuration>
+					<configFile>codestyles/tradional/eclipse-codestyle.xml</configFile>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
 				<configuration>
-					<configFile>codestyles/traditional/eclipse-codestyle.xml</configFile>
+					<configFile>codestyles/traditional/java-formatter.xml</configFile>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/domain/VerifierResult.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/domain/VerifierResult.java
@@ -22,14 +22,14 @@ public class VerifierResult
 
     private final boolean valid;
     private final List<ResultEntry> resultEntries;
-    
+
     public VerifierResult(boolean valid, List<ResultEntry> resultEntries)
     {
         super();
         this.valid = valid;
         this.resultEntries = resultEntries;
     }
-    
+
     public boolean isValid()
     {
         return valid;
@@ -39,7 +39,7 @@ public class VerifierResult
     {
         return resultEntries;
     }
-    
+
     @Override
     public int hashCode()
     {
@@ -49,7 +49,7 @@ public class VerifierResult
         result = prime * result + (valid ? 1231 : 1237);
         return result;
     }
-    
+
     @Override
     public boolean equals(Object obj)
     {
@@ -71,6 +71,7 @@ public class VerifierResult
             return false;
         return true;
     }
+
     @Override
     public String toString()
     {

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/mojo/VerifyMojo.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/mojo/VerifyMojo.java
@@ -60,7 +60,7 @@ public class VerifyMojo extends AbstractMojo
 
     /**
      * Variables which can be used in whitelist path attribute.
-     * 
+     *
      * <pre>
      * <configuration>
      *   <environments>

--- a/src/main/java/com/dataliquid/maven/distribution/verifier/service/VerifierService.java
+++ b/src/main/java/com/dataliquid/maven/distribution/verifier/service/VerifierService.java
@@ -67,7 +67,7 @@ public class VerifierService
 
             logger.info("Verifying whitelist files against distribution archive");
 
-            verificationStatus = verifyDistributionArchive(destinationDirectory, entries, destinationDirectory,verificationResults);
+            verificationStatus = verifyDistributionArchive(destinationDirectory, entries, destinationDirectory, verificationResults);
 
             logger.info("Verification completed.");
 
@@ -98,7 +98,8 @@ public class VerifierService
         return destinationDirectory;
     }
 
-    private boolean verifyDistributionArchive(File directory, List<Entry> entries, File originalDirectory, List<ResultEntry> verificationResults) throws Exception
+    private boolean verifyDistributionArchive(File directory, List<Entry> entries, File originalDirectory,
+            List<ResultEntry> verificationResults) throws Exception
     {
         boolean verificationStatus = true;
 
@@ -158,7 +159,8 @@ public class VerifierService
         return verificationStatus;
     }
 
-    private boolean verifyAllFilesInWhitelist(File directory, List<Entry> whitelistEntries, File originalDirectory, List<ResultEntry> verificationResults) throws Exception
+    private boolean verifyAllFilesInWhitelist(File directory, List<Entry> whitelistEntries, File originalDirectory,
+            List<ResultEntry> verificationResults) throws Exception
     {
         boolean allFilesFound = true;
         File[] directoryEntries = directory.listFiles();
@@ -166,10 +168,10 @@ public class VerifierService
         {
             if (directoryEntry.isDirectory())
             {
-               if(!verifyAllFilesInWhitelist(directoryEntry, whitelistEntries, originalDirectory, verificationResults))
-               {
-                   allFilesFound = false;
-               }
+                if (!verifyAllFilesInWhitelist(directoryEntry, whitelistEntries, originalDirectory, verificationResults))
+                {
+                    allFilesFound = false;
+                }
             }
             else
             {
@@ -182,8 +184,8 @@ public class VerifierService
         return allFilesFound;
     }
 
-    private boolean verifyFileInWhitelist(File subDirectory, List<Entry> entries, File originalDirectory, List<ResultEntry> verificationResults)
-            throws DOMException, NoSuchAlgorithmException, IOException
+    private boolean verifyFileInWhitelist(File subDirectory, List<Entry> entries, File originalDirectory,
+            List<ResultEntry> verificationResults) throws DOMException, NoSuchAlgorithmException, IOException
     {
         boolean exists = false;
         String strippedDirectory = FilenameUtils.normalize(subDirectory.getPath().replace(originalDirectory.getPath(), EMPTY), true);
@@ -240,7 +242,7 @@ public class VerifierService
 
     /**
      * Evaluate variable within given string value
-     * 
+     *
      * @param value
      *            lorem ${var} elit
      * @param variables

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/service/GenerateServiceTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/service/GenerateServiceTest.java
@@ -52,10 +52,8 @@ public class GenerateServiceTest
         verifierService.generate(distributionArchive, outputDirectory, whitelist);
 
         // then
-        assertThat(expectedWhitelist, isSimilarTo(whitelist)
-            .ignoreWhitespace()
-            .ignoreComments()
-            .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes)));
+        assertThat(expectedWhitelist, isSimilarTo(whitelist).ignoreWhitespace().ignoreComments()
+                .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAllAttributes)));
 
     }
 

--- a/src/test/java/com/dataliquid/maven/distribution/verifier/service/VerifierServiceTest.java
+++ b/src/test/java/com/dataliquid/maven/distribution/verifier/service/VerifierServiceTest.java
@@ -49,7 +49,7 @@ public class VerifierServiceTest
         variables = new HashMap<>();
         outputDirectory = new File("target/");
     }
-    
+
     @Test
     @SuppressWarnings("unchecked")
     public void shouldVerifyValid() throws Exception
@@ -57,26 +57,21 @@ public class VerifierServiceTest
         // given
         File whitelist = new File("src/test/resources/valid-fullmatch/whitelist.xml");
         File distributionArchive = new File("src/test/resources/valid-fullmatch/valid_fullmatch.zip");
-    
+
         // when
         VerifierResult verifierResult = verifierService.verify(distributionArchive, outputDirectory, whitelist, variables);
-    
+
         // then
-        final List<ResultEntry> verificationResults = verifierResult.getResultEntries();;
+        final List<ResultEntry> verificationResults = verifierResult.getResultEntries();
+        ;
         verificationResults.stream().forEach(System.out::println);
-        assertThat(verificationResults,contains( 
-                allOf(
-                    hasProperty("status", is("SUCCESS")),
-                    hasProperty("message", is("Validation passed successfully")), 
-                    hasProperty("path", is("/Sample.md")),
-                    hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
-                allOf(
-                        hasProperty("status", is("SUCCESS")),
-                        hasProperty("message", is("Validation passed successfully")), 
-                        hasProperty("path", is("/Sample.txt")),
-                        hasProperty("md5", is("193fa5e788a1800a760d1108051c2363")))
-                ));
-        
+        assertThat(verificationResults,
+                contains(
+                        allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                                hasProperty("path", is("/Sample.md")), hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
+                        allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                                hasProperty("path", is("/Sample.txt")), hasProperty("md5", is("193fa5e788a1800a760d1108051c2363")))));
+
         assertThat(verifierResult.isValid(), is(true));
     }
 
@@ -95,21 +90,15 @@ public class VerifierServiceTest
         VerifierResult verifierResult = verifierService.verify(distributionArchive, outputDirectory, whitelist, variables);
 
         // then
-        final List<ResultEntry> verificationResults = verifierResult.getResultEntries();;
+        final List<ResultEntry> verificationResults = verifierResult.getResultEntries();
+        ;
         verificationResults.stream().forEach(System.out::println);
-        assertThat(verificationResults,contains( 
-                allOf(
-                    hasProperty("status", is("SUCCESS")),
-                    hasProperty("message", is("Validation passed successfully")), 
-                    hasProperty("path", is("/Sample-1.0.0.md")),
-                    hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
-                allOf(
-                        hasProperty("status", is("SUCCESS")),
-                        hasProperty("message", is("Validation passed successfully")), 
-                        hasProperty("path", is("/Sample-myartifact.txt")),
-                        hasProperty("md5", is("193fa5e788a1800a760d1108051c2363")))
-                ));
-        
+        assertThat(verificationResults, contains(
+                allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                        hasProperty("path", is("/Sample-1.0.0.md")), hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
+                allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                        hasProperty("path", is("/Sample-myartifact.txt")), hasProperty("md5", is("193fa5e788a1800a760d1108051c2363")))));
+
         assertThat(verifierResult.isValid(), is(true));
     }
 
@@ -127,24 +116,15 @@ public class VerifierServiceTest
         // then
         final List<ResultEntry> verificationResults = verifierResult.getResultEntries();
         verificationResults.stream().forEach(System.out::println);
-        assertThat(verificationResults,contains( 
-                allOf(
-                    hasProperty("status", is("SUCCESS")),
-                    hasProperty("message", is("Validation passed successfully")), 
-                    hasProperty("path", is("/Sample.md")),
-                    hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
-                allOf(
-                        hasProperty("status", is("SUCCESS")),
-                        hasProperty("message", is("Validation passed successfully")), 
-                        hasProperty("path", is("/Sample.txt")),
-                        hasProperty("md5", is("193fa5e788a1800a760d1108051c2363"))),
-                allOf(
-                        hasProperty("status", is("FAILED")),
-                        hasProperty("message", is("Defined file not found")), 
-                        hasProperty("path", is("/Sample.adoc")),
-                        hasProperty("md5", is("193fa5e788a1800a760d1108051c7778")))
-                ));
-        
+        assertThat(verificationResults,
+                contains(
+                        allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                                hasProperty("path", is("/Sample.md")), hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
+                        allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                                hasProperty("path", is("/Sample.txt")), hasProperty("md5", is("193fa5e788a1800a760d1108051c2363"))),
+                        allOf(hasProperty("status", is("FAILED")), hasProperty("message", is("Defined file not found")),
+                                hasProperty("path", is("/Sample.adoc")), hasProperty("md5", is("193fa5e788a1800a760d1108051c7778")))));
+
         assertThat(verifierResult.isValid(), is(false));
     }
 
@@ -162,24 +142,15 @@ public class VerifierServiceTest
         // then
         final List<ResultEntry> verificationResults = verifierResult.getResultEntries();
         verificationResults.stream().forEach(System.out::println);
-        assertThat(verificationResults,contains( 
-                allOf(
-                    hasProperty("status", is("SUCCESS")),
-                    hasProperty("message", is("Validation passed successfully")), 
-                    hasProperty("path", is("/Sample.md")),
-                    hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
-                allOf(
-                        hasProperty("status", is("SUCCESS")),
-                        hasProperty("message", is("Validation passed successfully")), 
-                        hasProperty("path", is("/Sample.txt")),
-                        hasProperty("md5", is("193fa5e788a1800a760d1108051c2363"))),
-                allOf(
-                        hasProperty("status", is("FAILED")),
-                        hasProperty("message", is("File is not defined in whitelist")), 
-                        hasProperty("path", is("/Sample.adoc")),
-                        hasProperty("md5", is("0430eba9643b5e60e49c055eb16cbf7a")))
-                ));
-        
+        assertThat(verificationResults,
+                contains(
+                        allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                                hasProperty("path", is("/Sample.md")), hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
+                        allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                                hasProperty("path", is("/Sample.txt")), hasProperty("md5", is("193fa5e788a1800a760d1108051c2363"))),
+                        allOf(hasProperty("status", is("FAILED")), hasProperty("message", is("File is not defined in whitelist")),
+                                hasProperty("path", is("/Sample.adoc")), hasProperty("md5", is("0430eba9643b5e60e49c055eb16cbf7a")))));
+
         assertThat(verifierResult.isValid(), is(false));
     }
 
@@ -197,19 +168,14 @@ public class VerifierServiceTest
         // then
         final List<ResultEntry> verificationResults = verifierResult.getResultEntries();
         verificationResults.stream().forEach(System.out::println);
-        assertThat(verificationResults,contains( 
-                allOf(
-                    hasProperty("status", is("SUCCESS")),
-                    hasProperty("message", is("Validation passed successfully")), 
-                    hasProperty("path", is("/Sample.md")),
-                    hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
-                allOf(
-                        hasProperty("status", is("FAILED")),
-                        hasProperty("message", is("File found but with a different MD5 Checksum 193fa5e788a1800a760d1108051c2363")), 
-                        hasProperty("path", is("/Sample.txt")),
-                        hasProperty("md5", is("193fa5e788a1800a760d1108051c4711")))
-                ));
-        
+        assertThat(verificationResults,
+                contains(
+                        allOf(hasProperty("status", is("SUCCESS")), hasProperty("message", is("Validation passed successfully")),
+                                hasProperty("path", is("/Sample.md")), hasProperty("md5", is("4114b3e750902c5404ffe4864b3e11b8"))),
+                        allOf(hasProperty("status", is("FAILED")),
+                                hasProperty("message", is("File found but with a different MD5 Checksum 193fa5e788a1800a760d1108051c2363")),
+                                hasProperty("path", is("/Sample.txt")), hasProperty("md5", is("193fa5e788a1800a760d1108051c4711")))));
+
         assertThat(verifierResult.isValid(), is(false));
     }
 }


### PR DESCRIPTION
## Summary
- Upgraded parent-oss from 2.1.0 to 2.2.4
- Configured formatter-maven-plugin to use traditional style (java-formatter)
- Applied formatter to all Java source files
- Fixed formatter config file path after rename

## Changes
- Updated parent POM version to 2.2.4
- Added formatter configuration with traditional style
- Code reformatted according to traditional Java code style
- Updated config path from eclipse-codestyle.xml to java-formatter.xml

## Test plan
- [x] Maven build successful
- [x] Formatter validation passes (`mvn validate`)
- [x] CI mode validation tested (`CI=true mvn validate`)
- [x] CI pipeline passes

Closes #58