### PR TITLE
#62 Replace maven.compiler.release with source/target properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>8</maven.compiler.release>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 		<maven.version>3.9.11</maven.version>
 		<maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
 		<maven-plugin-plugin.version>3.15.1</maven-plugin-plugin.version>


### PR DESCRIPTION
## Summary
- Replaced maven.compiler.release property with maven.compiler.source and maven.compiler.target properties due to a known bug

## Test plan
- [x] CI build passes with Java 17 and 21
- [x] Project compiles successfully with mvn clean compile
- [x] All tests pass